### PR TITLE
Overload `schedule_*event` methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ pub struct DelayedMultiplier {
 impl DelayedMultiplier {
     pub fn input(&mut self, value: f64, scheduler: &Scheduler<Self>) {
         scheduler
-            .schedule_event_in(Duration::from_secs(1), Self::send, 2.0 * value)
+            .schedule_event(Duration::from_secs(1), Self::send, 2.0 * value)
             .unwrap();
     }
     async fn send(&mut self, value: f64) {

--- a/asynchronix/examples/espresso_machine.rs
+++ b/asynchronix/examples/espresso_machine.rs
@@ -141,7 +141,7 @@ impl Controller {
         // Schedule the `stop_brew()` method and turn on the pump.
         self.stop_brew_key = Some(
             scheduler
-                .schedule_keyed_event_in(self.brew_time, Self::stop_brew, ())
+                .schedule_keyed_event(self.brew_time, Self::stop_brew, ())
                 .unwrap(),
         );
         self.pump_cmd.send(PumpCommand::On).await;
@@ -274,7 +274,7 @@ impl Tank {
         let duration_until_empty = Duration::from_secs_f64(duration_until_empty);
 
         // Schedule the next update.
-        match scheduler.schedule_keyed_event_in(duration_until_empty, Self::set_empty, ()) {
+        match scheduler.schedule_keyed_event(duration_until_empty, Self::set_empty, ()) {
             Ok(set_empty_key) => {
                 let state = TankDynamicState {
                     last_volume_update: time,
@@ -431,7 +431,7 @@ fn main() {
     assert_eq!(flow_rate.take(), Some(0.0));
 
     // Interrupt the brew after 15s by pressing again the brew button.
-    simu.schedule_event_in(
+    simu.schedule_event(
         Duration::from_secs(15),
         Controller::brew_cmd,
         (),

--- a/asynchronix/examples/stepper_motor.rs
+++ b/asynchronix/examples/stepper_motor.rs
@@ -174,7 +174,7 @@ impl Driver {
 
             // Schedule the next pulse.
             scheduler
-                .schedule_event_in(pulse_duration, Self::send_pulse, ())
+                .schedule_event(pulse_duration, Self::send_pulse, ())
                 .unwrap();
         }
     }
@@ -224,7 +224,7 @@ fn main() {
     assert!(position.next().is_none());
 
     // Start the motor in 2s with a PPS of 10Hz.
-    simu.schedule_event_in(
+    simu.schedule_event(
         Duration::from_secs(2),
         Driver::pulse_rate,
         10.0,

--- a/asynchronix/src/lib.rs
+++ b/asynchronix/src/lib.rs
@@ -113,7 +113,7 @@
 //! }
 //! impl Delay {
 //!     pub fn input(&mut self, value: f64, scheduler: &Scheduler<Self>) {
-//!         scheduler.schedule_event_in(Duration::from_secs(1), Self::send, value).unwrap();
+//!         scheduler.schedule_event(Duration::from_secs(1), Self::send, value).unwrap();
 //!     }
 //!
 //!     async fn send(&mut self, value: f64) {
@@ -184,7 +184,7 @@
 //! #     }
 //! #     impl Delay {
 //! #         pub fn input(&mut self, value: f64, scheduler: &Scheduler<Self>) {
-//! #             scheduler.schedule_event_in(Duration::from_secs(1), Self::send, value).unwrap();
+//! #             scheduler.schedule_event(Duration::from_secs(1), Self::send, value).unwrap();
 //! #         }
 //! #         async fn send(&mut self, value: f64) { // this method can be private
 //! #             self.output.send(value).await;
@@ -242,7 +242,7 @@
 //!    [`Simulation::send_event()`](simulation::Simulation::send_event) or
 //!    [`Simulation::send_query()`](simulation::Simulation::send_query),
 //! 3. by scheduling events, using for instance
-//!    [`Simulation::schedule_event_in()`](simulation::Simulation::schedule_event_in).
+//!    [`Simulation::schedule_event()`](simulation::Simulation::schedule_event).
 //!
 //! Simulation outputs can be monitored using
 //! [`EventSlot`](simulation::EventSlot)s and
@@ -275,7 +275,7 @@
 //! #     }
 //! #     impl Delay {
 //! #         pub fn input(&mut self, value: f64, scheduler: &Scheduler<Self>) {
-//! #             scheduler.schedule_event_in(Duration::from_secs(1), Self::send, value).unwrap();
+//! #             scheduler.schedule_event(Duration::from_secs(1), Self::send, value).unwrap();
 //! #         }
 //! #         async fn send(&mut self, value: f64) { // this method can be private
 //! #             self.output.send(value).await;
@@ -354,10 +354,10 @@
 //!
 //! The first guarantee (and only the first) also extends to events scheduled
 //! from a simulation with a
-//! [`Simulation::schedule_*()`](simulation::Simulation::schedule_event_at)
-//! method: if the scheduler contains several events to be delivered at the same
-//! time to the same model, these events will always be processed in the order
-//! in which they were scheduled.
+//! [`Simulation::schedule_*()`](simulation::Simulation::schedule_event) method:
+//! if the scheduler contains several events to be delivered at the same time to
+//! the same model, these events will always be processed in the order in which
+//! they were scheduled.
 //!
 //! [actor_model]: https://en.wikipedia.org/wiki/Actor_model
 //! [pony]: https://www.ponylang.io/

--- a/asynchronix/src/time.rs
+++ b/asynchronix/src/time.rs
@@ -31,7 +31,7 @@
 //!
 //!     // Sets an alarm [input port].
 //!     pub fn set(&mut self, setting: MonotonicTime, scheduler: &Scheduler<Self>) {
-//!         if scheduler.schedule_event_at(setting, Self::ring, ()).is_err() {
+//!         if scheduler.schedule_event(setting, Self::ring, ()).is_err() {
 //!             println!("The alarm clock can only be set for a future time");
 //!         }
 //!     }
@@ -55,4 +55,4 @@ pub(crate) use scheduler::{
     schedule_periodic_event_at_unchecked, schedule_periodic_keyed_event_at_unchecked,
     ScheduledEvent, SchedulerQueue,
 };
-pub use scheduler::{EventKey, Scheduler, SchedulingError};
+pub use scheduler::{Deadline, EventKey, Scheduler, SchedulingError};

--- a/asynchronix/tests/model_scheduling.rs
+++ b/asynchronix/tests/model_scheduling.rs
@@ -15,7 +15,7 @@ fn model_schedule_event() {
     impl TestModel {
         fn trigger(&mut self, _: (), scheduler: &Scheduler<Self>) {
             scheduler
-                .schedule_event_at(scheduler.time() + Duration::from_secs(2), Self::action, ())
+                .schedule_event(scheduler.time() + Duration::from_secs(2), Self::action, ())
                 .unwrap();
         }
         async fn action(&mut self) {
@@ -51,14 +51,10 @@ fn model_cancel_future_keyed_event() {
     impl TestModel {
         fn trigger(&mut self, _: (), scheduler: &Scheduler<Self>) {
             scheduler
-                .schedule_event_at(scheduler.time() + Duration::from_secs(1), Self::action1, ())
+                .schedule_event(scheduler.time() + Duration::from_secs(1), Self::action1, ())
                 .unwrap();
             self.key = scheduler
-                .schedule_keyed_event_at(
-                    scheduler.time() + Duration::from_secs(2),
-                    Self::action2,
-                    (),
-                )
+                .schedule_keyed_event(scheduler.time() + Duration::from_secs(2), Self::action2, ())
                 .ok();
         }
         async fn action1(&mut self) {
@@ -100,14 +96,10 @@ fn model_cancel_same_time_keyed_event() {
     impl TestModel {
         fn trigger(&mut self, _: (), scheduler: &Scheduler<Self>) {
             scheduler
-                .schedule_event_at(scheduler.time() + Duration::from_secs(2), Self::action1, ())
+                .schedule_event(scheduler.time() + Duration::from_secs(2), Self::action1, ())
                 .unwrap();
             self.key = scheduler
-                .schedule_keyed_event_at(
-                    scheduler.time() + Duration::from_secs(2),
-                    Self::action2,
-                    (),
-                )
+                .schedule_keyed_event(scheduler.time() + Duration::from_secs(2), Self::action2, ())
                 .ok();
         }
         async fn action1(&mut self) {
@@ -148,7 +140,7 @@ fn model_schedule_periodic_event() {
     impl TestModel {
         fn trigger(&mut self, _: (), scheduler: &Scheduler<Self>) {
             scheduler
-                .schedule_periodic_event_at(
+                .schedule_periodic_event(
                     scheduler.time() + Duration::from_secs(2),
                     Duration::from_secs(3),
                     Self::action,
@@ -195,7 +187,7 @@ fn model_cancel_periodic_event() {
     impl TestModel {
         fn trigger(&mut self, _: (), scheduler: &Scheduler<Self>) {
             self.key = scheduler
-                .schedule_periodic_keyed_event_at(
+                .schedule_keyed_periodic_event(
                     scheduler.time() + Duration::from_secs(2),
                     Duration::from_secs(3),
                     Self::action,

--- a/asynchronix/tests/simulation_scheduling.rs
+++ b/asynchronix/tests/simulation_scheduling.rs
@@ -49,9 +49,9 @@ fn simulation_schedule_events() {
     let (mut simu, t0, addr, mut output) = simple_bench();
 
     // Queue 2 events at t0+3s and t0+2s, in reverse order.
-    simu.schedule_event_in(Duration::from_secs(3), PassThroughModel::input, (), &addr)
+    simu.schedule_event(Duration::from_secs(3), PassThroughModel::input, (), &addr)
         .unwrap();
-    simu.schedule_event_at(
+    simu.schedule_event(
         t0 + Duration::from_secs(2),
         PassThroughModel::input,
         (),
@@ -65,7 +65,7 @@ fn simulation_schedule_events() {
     assert!(output.next().is_some());
 
     // Schedule another event in 4s (at t0+6s).
-    simu.schedule_event_in(Duration::from_secs(4), PassThroughModel::input, (), &addr)
+    simu.schedule_event(Duration::from_secs(4), PassThroughModel::input, (), &addr)
         .unwrap();
 
     // Move to the 2nd event at t0+3s.
@@ -85,7 +85,7 @@ fn simulation_schedule_keyed_events() {
     let (mut simu, t0, addr, mut output) = simple_bench();
 
     let event_t1 = simu
-        .schedule_keyed_event_at(
+        .schedule_keyed_event(
             t0 + Duration::from_secs(1),
             PassThroughModel::input,
             1,
@@ -94,10 +94,10 @@ fn simulation_schedule_keyed_events() {
         .unwrap();
 
     let event_t2_1 = simu
-        .schedule_keyed_event_in(Duration::from_secs(2), PassThroughModel::input, 21, &addr)
+        .schedule_keyed_event(Duration::from_secs(2), PassThroughModel::input, 21, &addr)
         .unwrap();
 
-    simu.schedule_event_in(Duration::from_secs(2), PassThroughModel::input, 22, &addr)
+    simu.schedule_event(Duration::from_secs(2), PassThroughModel::input, 22, &addr)
         .unwrap();
 
     // Move to the 1st event at t0+1.
@@ -123,7 +123,7 @@ fn simulation_schedule_periodic_events() {
     let (mut simu, t0, addr, mut output) = simple_bench();
 
     // Queue 2 periodic events at t0 + 3s + k*2s.
-    simu.schedule_periodic_event_in(
+    simu.schedule_periodic_event(
         Duration::from_secs(3),
         Duration::from_secs(2),
         PassThroughModel::input,
@@ -131,7 +131,7 @@ fn simulation_schedule_periodic_events() {
         &addr,
     )
     .unwrap();
-    simu.schedule_periodic_event_at(
+    simu.schedule_periodic_event(
         t0 + Duration::from_secs(3),
         Duration::from_secs(2),
         PassThroughModel::input,
@@ -158,7 +158,7 @@ fn simulation_schedule_periodic_keyed_events() {
     let (mut simu, t0, addr, mut output) = simple_bench();
 
     // Queue 2 periodic events at t0 + 3s + k*2s.
-    simu.schedule_periodic_event_in(
+    simu.schedule_periodic_event(
         Duration::from_secs(3),
         Duration::from_secs(2),
         PassThroughModel::input,
@@ -167,7 +167,7 @@ fn simulation_schedule_periodic_keyed_events() {
     )
     .unwrap();
     let event2_key = simu
-        .schedule_periodic_keyed_event_at(
+        .schedule_keyed_periodic_event(
             t0 + Duration::from_secs(3),
             Duration::from_secs(2),
             PassThroughModel::input,


### PR DESCRIPTION
### Goal

This PR merges each `schedule_*event_in`/`schedule_*event_at` pair of methods into a single overloaded method accepting either a relative `Duration`or an absolute `MonotonicTime`.

This is a mitigation to the recent explosion of `schedule_*event` methods introduced by PRs #5 and #6.

### Impact

The API is not backward-compatible, but API compatibility was anyway already broken by PRs #5 and #6.
This PR does not add additional overhead.