### PR TITLE
Add send bound for Clock trait

### DIFF
--- a/asynchronix/src/time/clock.rs
+++ b/asynchronix/src/time/clock.rs
@@ -9,7 +9,7 @@ use crate::time::MonotonicTime;
 ///
 /// A clock can be associated to a simulation at initialization time by calling
 /// [`SimInit::init_with_clock()`](crate::simulation::SimInit::init_with_clock).
-pub trait Clock {
+pub trait Clock: Send {
     /// Blocks until the deadline.
     fn synchronize(&mut self, deadline: MonotonicTime) -> SyncStatus;
 }


### PR DESCRIPTION
Adding the Send bound allows to move `Simulation` into a thread again. I re-ran the tests and also tried a simulation based on the `SystemClock`, everything seems to work as intended.

 Fixes https://github.com/asynchronics/asynchronix/issues/14