### PR TITLE
small fix for new serde dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,7 @@ jobs:
 
       - name: Run cargo check
         run: cargo check
+        args: --all-features
 
   test:
     name: Test suite

--- a/asynchronix/Cargo.toml
+++ b/asynchronix/Cargo.toml
@@ -21,11 +21,11 @@ keywords = ["simulation", "discrete-event", "systems", "cyberphysical", "real-ti
 autotests = false
 
 [features]
+serde = ["dep:serde"]
 # API-unstable public exports meant for external test/benchmarking; development only.
 dev-hooks = []
 # Logging of performance-related statistics; development only.
 dev-logs = []
-serde = ["dep:serde"]
 
 [dependencies]
 async-event = "0.1"
@@ -43,6 +43,7 @@ st3 = "0.4"
 [dependencies.serde]
 version = "1"
 optional = true
+features = ["derive"]
 
 [target.'cfg(asynchronix_loom)'.dependencies]
 loom = "0.5"


### PR DESCRIPTION
I did not perform the check with `--all-features`, so I did not catch the compile error where the `derive` feature of serde was not activated. I added `--all-features` to the CI flags now so this is caught in the future.