### PR TITLE
Make the gRPC init more general

### DIFF
--- a/asynchronix/src/grpc/api/simulation.proto
+++ b/asynchronix/src/grpc/api/simulation.proto
@@ -38,7 +38,6 @@ message EventKey {
 }
 
 message InitRequest {
-    google.protobuf.Timestamp time = 1;
     bytes cfg = 2;
 }
 message InitReply {

--- a/asynchronix/src/grpc/codegen/simulation.rs
+++ b/asynchronix/src/grpc/codegen/simulation.rs
@@ -15,8 +15,6 @@ pub struct EventKey {
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct InitRequest {
-    #[prost(message, optional, tag = "1")]
-    pub time: ::core::option::Option<::prost_types::Timestamp>,
     #[prost(bytes = "vec", tag = "2")]
     pub cfg: ::prost::alloc::vec::Vec<u8>,
 }

--- a/asynchronix/src/grpc/run.rs
+++ b/asynchronix/src/grpc/run.rs
@@ -8,7 +8,7 @@ use serde::de::DeserializeOwned;
 use tonic::{transport::Server, Request, Response, Status};
 
 use crate::registry::EndpointRegistry;
-use crate::simulation::SimInit;
+use crate::simulation::{Scheduler, Simulation, SimulationError};
 
 use super::codegen::simulation::*;
 use super::key_registry::KeyRegistry;
@@ -19,11 +19,13 @@ use super::services::{ControllerService, MonitorService};
 ///
 /// The first argument is a closure that takes an initialization configuration
 /// and is called every time the simulation is (re)started by the remote client.
-/// It must create a new `SimInit` object complemented by a registry that
-/// exposes the public event and query interface.
+/// It must create a new simulation and its scheduler, complemented by a
+/// registry that exposes the public event and query interface.
 pub fn run<F, I>(sim_gen: F, addr: SocketAddr) -> Result<(), Box<dyn std::error::Error>>
 where
-    F: FnMut(I) -> (SimInit, EndpointRegistry) + Send + 'static,
+    F: FnMut(I) -> Result<(Simulation, Scheduler, EndpointRegistry), SimulationError>
+        + Send
+        + 'static,
     I: DeserializeOwned,
 {
     run_service(GrpcSimulationService::new(sim_gen), addr)
@@ -65,11 +67,13 @@ impl GrpcSimulationService {
     ///
     /// The argument is a closure that takes an initialization configuration and
     /// is called every time the simulation is (re)started by the remote client.
-    /// It must create a new `SimInit` object complemented by a registry that
-    /// exposes the public event and query interface.
+    /// It must create a new simulation and its scheduler, complemented by a
+    /// registry that exposes the public event and query interface.
     pub(crate) fn new<F, I>(sim_gen: F) -> Self
     where
-        F: FnMut(I) -> (SimInit, EndpointRegistry) + Send + 'static,
+        F: FnMut(I) -> Result<(Simulation, Scheduler, EndpointRegistry), SimulationError>
+            + Send
+            + 'static,
         I: DeserializeOwned,
     {
         Self {

--- a/asynchronix/src/grpc/services.rs
+++ b/asynchronix/src/grpc/services.rs
@@ -8,7 +8,7 @@ use prost_types::Timestamp;
 use tai_time::MonotonicTime;
 
 use super::codegen::simulation::{Error, ErrorCode};
-use crate::simulation::{ExecutionError, SchedulingError};
+use crate::simulation::{ExecutionError, SchedulingError, SimulationError};
 
 pub(crate) use controller_service::ControllerService;
 pub(crate) use init_service::InitService;
@@ -57,6 +57,14 @@ fn map_scheduling_error(error: SchedulingError) -> Error {
     let error_message = error.to_string();
 
     to_error(error_code, error_message)
+}
+
+/// Map a `SimulationError` to a Protobuf error.
+fn map_simulation_error(error: SimulationError) -> Error {
+    match error {
+        SimulationError::ExecutionError(e) => map_execution_error(e),
+        SimulationError::SchedulingError(e) => map_scheduling_error(e),
+    }
 }
 
 /// Attempts a cast from a `MonotonicTime` to a protobuf `Timestamp`.


### PR DESCRIPTION
Instead of producing a SimInit object, a bench is now expected to return a fully constructed simulation with its scheduler.

This means that the client does not necessarily need to provide the starting time for the simulation. This start time may be hardcoded in the bench, or may be taken as a parameter for the bench configuration.

This change make it possible for benches to do more, for instance to pre-schedule some events, or to do less, for instance by hardcoding the simulation time rather than accept an arbitrary simulation time.